### PR TITLE
Updated page about tx model: 'version' moved outside 'transaction'

### DIFF
--- a/docs/source/data-models/transaction-model.md
+++ b/docs/source/data-models/transaction-model.md
@@ -5,8 +5,8 @@ A transaction has the following structure:
 ```json
 {
     "id": "<hash of transaction, excluding signatures (see explanation)>",
+    "version": "<version number of the transaction model>",
     "transaction": {
-        "version": "<version number of the transaction model>",
         "fulfillments": ["<list of fulfillments>"],
         "conditions": ["<list of conditions>"],
         "operation": "<string>",
@@ -23,8 +23,8 @@ A transaction has the following structure:
 Here's some explanation of the contents of a transaction:
 
 - `id`: The hash of everything inside the serialized `transaction` body (i.e. `fulfillments`, `conditions`, `operation`, `timestamp` and `data`; see below), with one wrinkle: for each fulfillment in `fulfillments`, `fulfillment` is set to `null`. The `id` is also the database primary key.
+- - `version`: Version number of the transaction model, so that software can support different transaction models.
 - `transaction`:
-    - `version`: Version number of the transaction model, so that software can support different transaction models.
     - `fulfillments`: List of fulfillments. Each _fulfillment_ contains a pointer to an unspent asset
     and a _crypto fulfillment_ that satisfies a spending condition set on the unspent asset. A _fulfillment_
     is usually a signature proving the ownership of the asset.


### PR DESCRIPTION
For some reason, the "version" field was moved back outside the "transaction" inside the data model of a transaction. I updated the docs accordingly. For more context, see https://github.com/bigchaindb/bigchaindb/issues/755
